### PR TITLE
Bugfix: -t thread count ignored in correct_round1 

### DIFF
--- a/aligner-correct/correct_round1.h
+++ b/aligner-correct/correct_round1.h
@@ -12,6 +12,8 @@
 void correct_round2(chat_opt_t *chat_opt, hifiasm_opt_t *asm_opt);
 void correct_round1(chat_opt_t *chat_opt)
 {
+    // FIX: Add this line to use the user-specified thread count
+    int threads = chat_opt->thread_num; 
     std::cout << "correct_round1 thread:" << chat_opt->thread_num << std::endl;
     // PRINT_LINE_FUNC();
     // if (chat_opt->dBGFile != NULL)


### PR DESCRIPTION
## Summary / 概述
 `correct_round1` ignores the user-specified `-t` value when generating `recorrected.fa` and uses all available CPU cores.
`correct_round1` 在生成 `recorrected.fa` 时没有使用用户通过 `-t` 指定的线程数，而是占用所有可用 CPU 核心。

## Reproduction / 复现方式
1. Run DeChat with `-t 16`
2. Check CPU usage during the first polish stage (`correct_round1`)
3. It uses all cores instead of 16 threads


1. 使用 `-t 16` 运行 DeChat
2. 观察第一次 polish（`correct_round1`）阶段的 CPU 使用情况
3. 实际会使用全部核心，而不是 16 线程
<img width="1279" height="854" alt="屏幕截图 2025-12-26 223153" src="https://github.com/user-attachments/assets/6c24861f-bf7e-44b2-9a59-d725be6a56a8" />

## Root cause / 原因
 `Dispatcher(threads)` uses a global `threads` (default `0`), and `0` means "use all cores" in GATB Dispatcher. `chat_opt->thread_num` was not applied.
`Dispatcher(threads)` 实际使用了全局 `threads`（默认 `0`），而 `0` 在 GATB Dispatcher 中表示“自动使用全部核心”。`chat_opt->thread_num` 没有被用于设置线程数。

## Fix / 修复
Define a local `threads` in `correct_round1(chat_opt_t *chat_opt)` and set it to `chat_opt->thread_num`, so `Dispatcher` respects `-t/`.
在 `correct_round1(chat_opt_t *chat_opt)` 内新增局部变量 `threads = chat_opt->thread_num`，使 `Dispatcher` 按 `-t` 运行。
## After fix / 修复后
<img width="1330" height="875" alt="屏幕截图 2025-12-26 222520" src="https://github.com/user-attachments/assets/b9e4b2a3-a7b9-4eba-83b7-d068fcf4f0b6" />
